### PR TITLE
Update com.microsoft.OneDrive.json

### DIFF
--- a/manifests/ManagedPreferencesApplications/com.microsoft.OneDrive.json
+++ b/manifests/ManagedPreferencesApplications/com.microsoft.OneDrive.json
@@ -155,7 +155,7 @@
         },
         "SharePointOnPremPrioritizationPolicy": {
             "type": "integer",
-            "title": "SharePoint On-Prem Prioritization",
+            "title": "SharePoint On-Premises Prioritization",
             "description": "Determines whether or not the client should set up sync for SharePoint Server or SharePoint Online first during the first-run scenario.",
             "links": [
                 {
@@ -170,7 +170,7 @@
             "options": {
                 "enum_titles": [
                     "SharePoint Online",
-                    "SharePoint Server (On-Prem)"
+                    "SharePoint Server (On-Premises)"
                 ]
             },
             "property_order": 55
@@ -185,6 +185,7 @@
                     "href": "https://learn.microsoft.com/en-us/sharepoint/deploy-and-configure-on-macos#filesondemandenabled"
                 }
             ],
+            "default": true,
             "property_order": 70
         },
         "HydrationDisallowedApps": {
@@ -224,6 +225,7 @@
                     "href": "https://learn.microsoft.com/en-us/sharepoint/deploy-and-configure-on-macos#enableallocsiclients"
                 }
             ],
+            "default": true,
             "property_order": 90
         },
         "DisableHydrationToast": {
@@ -236,6 +238,7 @@
                     "href": "https://learn.microsoft.com/en-us/sharepoint/deploy-and-configure-on-macos#disablehydrationtoast"
                 }
             ],
+            "default": false,
             "property_order": 95
         },
         "BlockExternalSync": {
@@ -248,6 +251,7 @@
                     "href": "https://learn.microsoft.com/en-us/sharepoint/deploy-and-configure-on-macos#blockexternalsync"
                 }
             ],
+            "default": false,
             "property_order": 100
         },
         "AllowTenantList": {
@@ -296,8 +300,8 @@
         },
         "KFMOptInWithWizard": {
             "type": "string",
-            "title": "Known Folder Move - Present opt-in wizard to users",
-            "description": "Enter your tenant ID to present users with Known Folder Move wizard.\n\nThis setting displays a wizard that prompts users to move their Documents and Desktop folders to OneDrive.\n\nIf you enable this setting and provide your tenant ID, users who are syncing their OneDrive will see the Folder Backup wizard window when they're signed in. If they close the window, a reminder notification appears in the Sync Activity Center until they move their Desktop and Documents folders.",
+            "title": "Known Folder Move - Present opt-in wizard to users - Tenant ID",
+            "description": "Enter your Tenant ID to present users with Known Folder Move wizard.\n\nThis setting displays a wizard that prompts users to move their Documents and Desktop folders to OneDrive.\n\nIf you enable this setting and provide your tenant ID, users who are syncing their OneDrive will see the Folder Backup wizard window when they're signed in. If they close the window, a reminder notification appears in the Sync Activity Center until they move their Desktop and Documents folders.",
             "links": [
                 {
                     "rel": "More information",
@@ -308,8 +312,8 @@
         },
         "KFMSilentOptIn": {
             "type": "string",
-            "title": "Known Folder Move - Silent Opt-in",
-            "description": "Enter your tenant ID to redirect and move your users' Documents and/or Desktop folders to OneDrive without any user interaction.",
+            "title": "Known Folder Move - Silent Opt-in - Tenant ID",
+            "description": "Enter your Tenant ID to redirect and move your users' Documents and/or Desktop folders to OneDrive without any user interaction.",
             "links": [
                 {
                     "rel": "More information",
@@ -320,7 +324,7 @@
         },
         "KFMSilentOptInDesktop": {
             "type": "boolean",
-            "title": "Known Folder Move - Silent Opt-in - Desktop folder",
+            "title": "Known Folder Move - Silent Opt-in - backup Desktop folder",
             "description": "Sync the user's Desktop folder to OneDrive using Known Folder Move. Requires the tenant ID to be configured in \"Known Folder Move - Silent Opt-in\".",
             "links": [
                 {
@@ -332,7 +336,7 @@
         },
         "KFMSilentOptInDocuments": {
             "type": "boolean",
-            "title": "Known Folder Move - Silent Opt-in - Documents folder",
+            "title": "Known Folder Move - Silent Opt-in - backup Documents folder",
             "description": "Sync the user's Documents folder to OneDrive using Known Folder Move. Requires the tenant ID to be configured in \"Known Folder Move - Silent Opt-in\".",
             "links": [
                 {
@@ -376,6 +380,7 @@
                     "href": "https://learn.microsoft.com/en-us/sharepoint/deploy-and-configure-on-macos#kfmblockoptin"
                 }
             ],
+            "default": 0,
             "property_order": 140
         },
         "KFMBlockOptOut": {
@@ -388,11 +393,12 @@
                     "href": "https://learn.microsoft.com/en-us/sharepoint/deploy-and-configure-on-macos#kfmblockoptout"
                 }
             ],
+            "default": false,
             "property_order": 145
         },
         "DisableAutoConfig": {
             "type": "integer",
-            "title": "Disable Automatic Configuration",
+            "title": "Automatic Configuration",
             "description": "This setting determines whether or not the sync app can automatically sign in. If you set this setting's value to 1, the sync app is prevented from automatically signing with an existing Microsoft Azure Active Directory (Azure AD) credential that is made available to Microsoft applications.",
             "links": [
                 {
@@ -410,18 +416,32 @@
                     "Prevent automatically signing with an existing AzureAD account."
                 ]
             },
+            "default": 0,
             "property_order": 150
         },
         "Tier": {
             "type": "string",
-            "title": "Disable Automatic Configuration",
-            "description": "This setting determines whether or not the sync app can automatically sign in. If you set this setting's value to 1, the sync app is prevented from automatically signing with an existing Microsoft Azure Active Directory (Azure AD) credential that is made available to Microsoft applications.",
+            "title": "Update tier",
+            "description": "Specify the sync app update ring for users in your organization.",
             "links": [
                 {
                     "rel": "More information",
                     "href": "https://learn.microsoft.com/en-us/sharepoint/deploy-and-configure-on-macos#disableautoconfig"
                 }
             ],
+            "enum": [
+                "Insiders",
+                "Production",
+                "Enterprise"
+            ],
+            "options": {
+                "enum_titles": [
+                    "Insiders - preview new features",
+                    "Production - latest features as they become available",
+                    "Enterprise - get new features, bug fixes, and performance improvements last"
+                ]
+            },
+            "default": "Production",
             "property_order": 150
         }
     }


### PR DESCRIPTION
Updated all "More information" URLs to point to new learn.microsoft.com domain. Updated names for "Known Folder Move" preferences to make them more logically grouped. Updated typo in "SharePointOnPremPrioritizationPolicy" property. Added more information and links for "Known Folder Move" preferences. Added preferences added to [the documentation](https://learn.microsoft.com/en-us/sharepoint/deploy-and-configure-on-macos) like Tier. Removed preferences no longer referred to by [the documentation](https://learn.microsoft.com/en-us/sharepoint/deploy-and-configure-on-macos) at (DefaultToBusinessFRE, EnableAddAccounts, IsHydrationToastAllowed). Added more "defaults" throughout.